### PR TITLE
Support multiple eval rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Llmkit's evaluation system allows you to:
 
 1. Create evaluation test sets with specific inputs
 ![Evaluation Creation](assets/eval_create.png)
-2. Run those inputs against different prompt versions
+2. Run those inputs against different prompt versions. You can repeat a run multiple times using the `rounds` option to gather varied outputs.
 3. Score and compare performance
 ![Evaluation Scoring](assets/eval_score.png)
 4. Track improvements over time

--- a/backend/migrations/20250501000000_add_run_id_to_log.sql
+++ b/backend/migrations/20250501000000_add_run_id_to_log.sql
@@ -1,0 +1,1 @@
+ALTER TABLE log ADD COLUMN run_id TEXT;

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,67 @@
+openapi: 3.0.0
+info:
+  title: llmkit API
+  version: 1.0.0
+paths:
+  /v1/ui/prompt-eval-runs/{prompt_id}/version/{prompt_version_id}:
+    post:
+      summary: Execute prompt eval runs
+      parameters:
+        - name: prompt_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: prompt_version_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: rounds
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PromptEvalExecutionRunResponse'
+components:
+  schemas:
+    PromptEvalRunResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        run_id:
+          type: string
+        prompt_version_id:
+          type: integer
+        prompt_eval_id:
+          type: integer
+        prompt_eval_name:
+          type: string
+        score:
+          type: integer
+          nullable: true
+        output:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    PromptEvalExecutionRunResponse:
+      type: object
+      properties:
+        run_id:
+          type: string
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromptEvalRunResponse'

--- a/backend/tests/eval_runs.rs
+++ b/backend/tests/eval_runs.rs
@@ -1,0 +1,24 @@
+use backend::{controllers::prompt_eval_run::{execute_eval_run, EvalRunParams}, AppState, db::init::DbData};
+use axum::extract::{Path, Query, State};
+
+#[tokio::test]
+async fn multiple_rounds_create_rows() {
+    let data = DbData::new("sqlite::memory:").await.unwrap();
+    let state = AppState::new(data.clone()).await;
+
+    // use first prompt from seeded data
+    let prompt = data.prompt.list_prompts().await.unwrap().first().cloned().unwrap();
+
+    // create eval for prompt
+    let _ = data.prompt_eval.create(prompt.id, None, "hi".to_string(), "human", Some("t".to_string())).await.unwrap();
+
+    let params = EvalRunParams { rounds: Some(2) };
+    let _ = execute_eval_run(
+        Path((prompt.id, prompt.version_id)),
+        State(state.clone()),
+        Query(params),
+    ).await.unwrap();
+
+    let runs = data.prompt_eval_run.get_by_prompt_version(prompt.version_id).await.unwrap();
+    assert_eq!(runs.len(), 2);
+}

--- a/ui/components/evals/view-prompt-eval-input.vue
+++ b/ui/components/evals/view-prompt-eval-input.vue
@@ -52,6 +52,7 @@
             <p class="mt-2 text-sm text-neutral-700 dark:text-neutral-300">View eval performance for the current version of your prompt.</p>
           </div>
           <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none flex items-center space-x-2">
+            <input type="number" min="1" v-model.number="rounds" class="w-16 border px-1 py-0.5 mr-2" />
             <PrimaryButton
               @click="executeEvalRun()"
               v-if="requiresEvalRun"
@@ -146,6 +147,7 @@ const emits = defineEmits<{
 }>();
 
 const mode = ref<"view" | "score-eval-run">("view")
+const rounds = ref(1)
 
 const { createEvalRun, fetchEvalRunByPromptVersion, evalRuns, loading: evalRunsLoading } = usePromptEvalRuns();
 await fetchEvalRunByPromptVersion(props.prompt.id, props.prompt.version_id)
@@ -193,7 +195,7 @@ const executeLoading = ref(false)
 
 async function executeEvalRun() {
   executeLoading.value = true
-  await createEvalRun(props.prompt.id, props.prompt.version_id)
+  await createEvalRun(props.prompt.id, props.prompt.version_id, rounds.value)
   mode.value = 'score-eval-run'
   executeLoading.value = false
 }

--- a/ui/composables/usePromptEvalRuns.ts
+++ b/ui/composables/usePromptEvalRuns.ts
@@ -42,14 +42,14 @@ export const usePromptEvalRuns = () => {
   //   }
   // }
 
-  const createEvalRun = async (promptId: number, promptVersionId: number) => {
+  const createEvalRun = async (promptId: number, promptVersionId: number, rounds: number) => {
     try {
-      const newEval = await $fetch<PromptEvalExecutionRunResponse>(`/v1/ui/prompt-eval-runs/${promptId}/version/${promptVersionId}`, {
+      const newEval = await $fetch<PromptEvalExecutionRunResponse[]>(`/v1/ui/prompt-eval-runs/${promptId}/version/${promptVersionId}?rounds=${rounds}`, {
         method: 'POST',
       })
 
-      newEval.runs.forEach(r => {
-        evalRuns.value.push(r)
+      newEval.forEach(group => {
+        group.runs.forEach(r => evalRuns.value.push(r))
       })
 
       loading.value = false

--- a/ui/pages/docs/eval.md
+++ b/ui/pages/docs/eval.md
@@ -1,0 +1,3 @@
+# Prompt Evaluation
+
+Use the **Eval Runner** to execute your evaluation tests against a prompt version. Set the **Rounds** value to repeat the run multiple times. Each round generates a unique run id so you can compare outputs.


### PR DESCRIPTION
## Summary
- allow multiple eval rounds in API via new `rounds` query parameter
- update evaluator handler and route to loop for each round and return a list of run groups
- document the new parameter in `openapi.yaml` and README
- expose rounds field in the UI and composables
- basic integration test for multi-round execution
- add migration for optional log column
- add frontend docs page for eval usage

## Testing
- `cargo test` *(fails: could not fetch `openrouter_api` dependency)*